### PR TITLE
This commit fixes the dropdown on models page and spacing in navbar of prompts page

### DIFF
--- a/frontend/pages/prompts/[path].tsx
+++ b/frontend/pages/prompts/[path].tsx
@@ -86,7 +86,7 @@ export default function PromptsPage() {
       <div className="pg-header">
         <div className="pg-header-section pg-header-title flex justify-between">
           <h1 className="pg-page-title">Prompts</h1>
-          <div className="flex">
+          <div className="flex space-x-2">
             <InputField
               placeholder="Search prompts"
               onInputChange={(value) => {setQuery(value); search(value)}}

--- a/frontend/src/components/Form/DropDown.tsx
+++ b/frontend/src/components/Form/DropDown.tsx
@@ -36,22 +36,27 @@ export default function DropDown({
           {label}
         </label>
       )}
-      <select
-        id="location"
-        name="location"
-        className="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
-        onChange={handleSelectChange}
-        value={selected}
-      >
-        {options.map((option, index) => (
-          <option
+      <div className="grid">
+        <svg className="pointer-events-none z-10 right-1 relative col-start-1 row-start-1 h-4 w-4 self-center justify-self-end forced-colors:hidden" viewBox="0 0 16 16" fill="currentColor">
+          <path fillRule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"></path>
+        </svg>
+        <select
+          id="location"
+          name="location"
+          className="block appearance-none row-start-1 col-start-1 w-full rounded-md py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
+          onChange={handleSelectChange}
+          value={selected}
+          >
+          {options.map((option, index) => (
+            <option
             key={index}
             value={option.value === undefined ? 'none' : option.value}
-          >
-            {option.name}
-          </option>
-        ))}
-      </select>
+            >
+              {option.name}
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Change the default select tag and make it tailwind css way, a grid of select tag and a svg icon
<img width="1097" alt="Screenshot 2024-02-02 at 11 44 29 PM" src="https://github.com/promptdesk/promptdesk/assets/27822551/bf11e43b-6cf8-4b2f-9a19-8e90b1da2a2f">

- add class for spacing
<img width="508" alt="Screenshot 2024-02-02 at 11 44 43 PM" src="https://github.com/promptdesk/promptdesk/assets/27822551/9ff204d2-0741-4ae9-bdca-9731d34e1cda">
